### PR TITLE
Directly get gems from the defined source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 gem 'aws-sdk'
 gem 'dotenv'
 gem 'sinatra'
+source 'https://rubygems.org'


### PR DESCRIPTION
If Full Ruby on Rails is not installed on the system, user may have to install gems individually. With this update all the gems will be directly downloaded from the specified source.